### PR TITLE
Added support for installing extensions.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+common --record_rule_instantiation_callstack

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,17 +1,1 @@
 package(default_visibility = ["//visibility:private"])
-
-genrule(
-    name = "az_genrule",
-    srcs = [],
-    outs = ["az.sh"],
-    cmd = """
-      echo -e 'AZURE_EXTENSION_DIR="$(AZURE_EXTENSION_DIR)" $(AZ_PATH) $$*' > \"$@\"
-    """,
-    toolchains = ["@az_config//:toolchain"],
-)
-
-sh_binary(
-    name = "az",
-    srcs = ["az.sh"],
-    visibility = ["//visibility:public"],
-)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,3 +3,13 @@ workspace(name = "rules_microsoft_azure")
 load("@rules_microsoft_azure//repositories:repositories.bzl", microsoft_azure_repositories = "repositories")
 
 microsoft_azure_repositories()
+
+load("@az//:extension.bzl", az_extension = "extension")
+
+az_extension(
+    name = "install_extension",
+    extensions = {
+        "databricks": "",
+        "datafactory": "",
+    },
+)

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:private"])

--- a/repositories/BUILD.bazel
+++ b/repositories/BUILD.bazel
@@ -6,19 +6,3 @@ filegroup(
     srcs = glob(["**"]),
     visibility = ["//visibility:public"],
 )
-
-genrule(
-    name = "az_genrule",
-    srcs = [],
-    outs = ["az.sh"],
-    cmd = """
-    echo -e 'AZURE_EXTENSION_DIR="$(AZURE_EXTENSION_DIR)" $(AZ_PATH) $$*' > \"$@\"
-    """,
-    toolchains = ["@az_config//:toolchain"],
-)
-
-sh_binary(
-    name = "az",
-    srcs = ["az.sh"],
-    visibility = ["//visibility:public"],
-)

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -11,4 +11,4 @@ def repositories():
 
     native.register_toolchains("@rules_microsoft_azure//toolchain/az:default_linux_toolchain")
 
-    az_toolchain_configure(name = "az_config")
+    az_toolchain_configure(name = "az")

--- a/toolchain/az/BUILD.bazel.tpl
+++ b/toolchain/az/BUILD.bazel.tpl
@@ -1,7 +1,7 @@
 """
 This BUILD file is auto-generated from toolchain/az/BUILD.bazel.tpl
 """
-package(default_visibility = ["//visibility:public"])
+# package(default_visibility = ["//visibility:public"])
 
 load("@rules_microsoft_azure//toolchain/az:toolchain.bzl", "az_toolchain")
 
@@ -9,4 +9,16 @@ az_toolchain(
     name = "toolchain",
     az_path = "%{AZ_PATH}",
     azure_extension_dir = "%{AZURE_EXTENSION_DIR}",
+    visibility = ["//visibility:public"],
+)
+
+exports_files([
+    "az.sh",
+    "extension.bzl",
+])
+
+sh_binary(
+    name = "cli",
+    srcs = ["az.sh"],
+    visibility = ["//visibility:public"],
 )

--- a/toolchain/az/BUILD.bazel.tpl
+++ b/toolchain/az/BUILD.bazel.tpl
@@ -1,8 +1,6 @@
 """
 This BUILD file is auto-generated from toolchain/az/BUILD.bazel.tpl
 """
-# package(default_visibility = ["//visibility:public"])
-
 load("@rules_microsoft_azure//toolchain/az:toolchain.bzl", "az_toolchain")
 
 az_toolchain(

--- a/toolchain/az/configure.bzl
+++ b/toolchain/az/configure.bzl
@@ -5,7 +5,6 @@ def _toolchain_configure_impl(repository_ctx):
     else:
         fail("")
 
-    # é bom definir um diretório no cache para armazenar apenas as extenções, e não misturar com as que já existem na cli.
     azure_extension_dir = ""
     if repository_ctx.attr.azure_extension_dir:
         azure_extension_dir = repository_ctx.attr.azure_extension_dir
@@ -16,14 +15,34 @@ def _toolchain_configure_impl(repository_ctx):
     else:
         fail("")
 
-    print(az_path)
-    print(azure_extension_dir)
+    az_script_name = "az.sh"
+    repository_ctx.file(
+        az_script_name,
+        content = """#!/usr/bin/env bash
+# Immediately exit if any command fails.
+# set -e
+export AZURE_EXTENSION_DIR="{0}"
+
+{1} $*
+""".format(azure_extension_dir, az_path),
+        executable = True,
+    )
+
     repository_ctx.template(
         "BUILD.bazel",
         Label("@rules_microsoft_azure//toolchain/az:BUILD.bazel.tpl"),
         {
             "%{AZ_PATH}": str(az_path),
             "%{AZURE_EXTENSION_DIR}": str(azure_extension_dir),
+        },
+        False,
+    )
+
+    repository_ctx.template(
+        "extension.bzl",
+        Label("@rules_microsoft_azure//toolchain/az:extension.bzl.tpl"),
+        {
+            "%{LABEL_SCRIPT_AZ}": "@%s//:%s" % (str(repository_ctx.name), str(az_script_name)),
         },
         False,
     )

--- a/toolchain/az/configure.bzl
+++ b/toolchain/az/configure.bzl
@@ -20,7 +20,7 @@ def _toolchain_configure_impl(repository_ctx):
         az_script_name,
         content = """#!/usr/bin/env bash
 # Immediately exit if any command fails.
-# set -e
+set -e
 export AZURE_EXTENSION_DIR="{0}"
 
 {1} $*

--- a/toolchain/az/extension.bzl.tpl
+++ b/toolchain/az/extension.bzl.tpl
@@ -1,0 +1,34 @@
+def _extension(repository_ctx):
+    repository_ctx.report_progress("Installation extensions for Azure CLI")
+    az = repository_ctx.path(Label("%{LABEL_SCRIPT_AZ}"))
+
+    for (e, v) in repository_ctx.attr.extensions.items():
+        if v == "":
+            v = "latest"
+
+        repository_ctx.report_progress("Installing extension (name: %s, version: %s)" % (e, v))
+        result = repository_ctx.execute(
+            [az, "extension", "add", "--yes", "--name", str(e), "--version", v],
+            timeout = repository_ctx.attr.timeout,
+            quiet = False,
+        )
+
+        if result.return_code:
+            fail("Install extension failed: (stdout: %s, stderr: %s)" % (result.stdout, result.stderr))
+
+extension = repository_rule(
+    implementation = _extension,
+    attrs = {
+        "extensions": attr.string_dict(
+            mandatory = False,
+        ),
+        "timeout": attr.int(
+            mandatory = False,
+            default = 3600,
+            doc = """Maximum duration of the extension manager execution in seconds.""",
+        ),
+    },
+    environ = [
+        "PATH",
+    ],
+)


### PR DESCRIPTION
Azure CLI has a subcommand responsible for managing custom extensions.
These extensions are not natively shipped in the azure cli binary, and for this reason,
a repository rule has been developed to handle the installation of new extensions.

References: https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview?view=azure-cli-latest