### PR TITLE
Added resource_name attribute for az_datafactory rule

### DIFF
--- a/az/private/rules/datafactory/main.bzl
+++ b/az/private/rules/datafactory/main.bzl
@@ -26,7 +26,7 @@ def _impl(ctx):
                 az_action,
                 ctx.attr.config[AzConfigInfo].global_args,
                 "--factory-name \"%s\"" % ctx.attr.factory_name,
-                "--name \"%s\"" % ctx.attr.generator_name.split(".")[0],
+                "--name \"%s\"" % ctx.attr.resource_name,
                 "--resource-group \"%s\"" % ctx.attr.resource_group,
             ]
 
@@ -71,12 +71,15 @@ _common_attr = {
     "factory_name": attr.string(
         mandatory = True,
     ),
-    "resource_group": attr.string(
-        mandatory = True,
-    ),
     "resource": attr.string(
         mandatory = False,
         values = ["pipeline", "trigger"],
+    ),
+    "resource_group": attr.string(
+        mandatory = True,
+    ),
+    "resource_name": attr.string(
+        mandatory = True,
     ),
     "template": attr.label(
         mandatory = True,

--- a/docs/az_datafactory.md
+++ b/docs/az_datafactory.md
@@ -6,8 +6,9 @@ az_datafactory(
     name,
     config,
     factory_name,
-    resource_group,
     resource,
+    resource_group,
+    resource_name,
     template
 )
 ```
@@ -47,6 +48,14 @@ A rule for setting basic properties for other rules.
       </td>
     </tr>
     <tr>
+      <td><code>resource</code></td>
+      <td>
+        <p><code>String, required</code></p>
+        <p>The type of the object in the DataFactory.</p>
+        <p>Supported values ​​are: <code>pipeline</code> and <code>trigger</code>.<p>
+      </td>
+    </tr>
+    <tr>
       <td><code>resource_group</code></td>
       <td>
         <p><code>String, required</code></p>
@@ -54,11 +63,10 @@ A rule for setting basic properties for other rules.
       </td>
     </tr>
     <tr>
-      <td><code>resource</code></td>
+      <td><code>resource_name</code></td>
       <td>
         <p><code>String, required</code></p>
-        <p>The type of the object in the DataFactory.</p>
-        <p>Supported values ​​are: <code>pipeline</code> and <code>trigger</code>.<p>
+        <p>The resource name (pipeline or trigger).</p>
       </td>
     </tr>
     <tr>
@@ -99,8 +107,9 @@ az_datafactory(
     name = "foo",
     config = ":config",
     factory_name = "foo-factory",
-    resource_group = "foo-factory-rg",
     resource = "pipeline",
+    resource_group = "foo-factory-rg",
+    resource_name = "foo",
     template = ":template",
 )
 ```

--- a/examples/datafactory/BUILD.bazel
+++ b/examples/datafactory/BUILD.bazel
@@ -6,6 +6,7 @@ az_datafactory(
     factory_name = "dev-wus2-datahub-df",
     resource = "pipeline",
     resource_group = "dev-wus2-datahub-rg",
+    resource_name = "foo",
     template = ":pipeline.json",
 )
 
@@ -15,6 +16,7 @@ az_datafactory(
     factory_name = "dev-wus2-datahub-df",
     resource = "trigger",
     resource_group = "dev-wus2-datahub-rg",
+    resource_name = "bar",
     template = ":trigger.json",
 )
 


### PR DESCRIPTION
When using the az_datafactory rule to create a pipeline or trigger, the resource name was the same as the target.
To be more flexible in defining resource names, a new attribute was added just to receive this value.
This change refers to issue #13.