### PR TITLE
Stamp support for the subscription attribute in the az_config rule.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,4 @@
 common --record_rule_instantiation_callstack
+
+build --workspace_status_command=tools/workspace_status.sh
+run --workspace_status_command=tools/workspace_status.sh

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,1 +1,6 @@
 package(default_visibility = ["//visibility:private"])
+
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# gazelle:prefix github.com/acqio/rules_microsoft_azure
+gazelle(name = "gazelle")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,6 +26,6 @@ az_toolchain_configure(
 az_config(
     name = "dev",
     debug = False,
-    subscription = "dev-subscription",
+    subscription = "{STABLE_AZ_SUBSCRIPTION}",
     verbose = False,
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,8 +1,21 @@
 workspace(name = "rules_microsoft_azure")
 
-load("@rules_microsoft_azure//az:deps.bzl", "az_config", "az_rules_repositories", "az_toolchain_configure")
+load("@rules_microsoft_azure//az/private:repositories.bzl", az_repositories = "repositories")
 
-az_rules_repositories()
+az_repositories()
+
+load(
+    "@rules_microsoft_azure//az:deps.bzl",
+    "az_config",
+    "az_dependencies",
+    "az_toolchain_configure",
+)
+
+az_dependencies()
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
 
 az_toolchain_configure(
     extensions = {

--- a/az/deps.bzl
+++ b/az/deps.bzl
@@ -1,7 +1,11 @@
-load("//az/private:repositories.bzl", _az_rules_repositories = "repositories")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("//az/toolchain:configure.bzl", _az_toolchain_configure = "toolchain_configure")
 load("//az/private:rules/config.bzl", _az_config = "config_alias")
 
-az_rules_repositories = _az_rules_repositories
 az_toolchain_configure = _az_toolchain_configure
 az_config = _az_config
+
+def az_dependencies():
+    go_rules_dependencies()
+
+    go_register_toolchains()

--- a/az/go/cmd/stamper/BUILD.bazel
+++ b/az/go/cmd/stamper/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["stamper.go"],
+    importpath = "github.com/acqio/rules_microsoft_azure/az/go/cmd/stamper",
+    visibility = ["//visibility:private"],
+    deps = ["//az/go/pkg/utils:go_default_library"],
+)
+
+go_binary(
+    name = "stamper",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/az/go/cmd/stamper/stamper.go
+++ b/az/go/cmd/stamper/stamper.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+    "flag"
+    "log"
+    "bufio"
+    "os"
+    "strings"
+    "fmt"
+
+    "github.com/acqio/rules_microsoft_azure/az/go/pkg/utils"
+)
+
+var (
+    format        = flag.String("format", "", "The format string containing stamp variables.")
+    output        = flag.String("output", "", "The filename into which we write the result.")
+    stampInfoFile utils.ArrayStringFlags
+)
+
+func main() {
+
+    flag.Var(&stampInfoFile,"stamp-info-file", "A list of files from which to read substitutions\n" +
+                                               "to make in the provided --name, e.g. {BUILD_USER}")
+    flag.Parse()
+
+    if *format == "" {
+        log.Fatalln("Required option -format was not specified.")
+    }
+    if *output == "" {
+        log.Fatalln("Required option -output was not specified.")
+    }
+    if len(stampInfoFile) == 0 {
+        log.Fatalln("Required option --stamp-info-file is required.")
+    }
+
+    format_args := make(map[string]string)
+
+    for _, filePath := range stampInfoFile {
+        readFile, err := os.Open(filePath)
+
+        if err != nil {
+            log.Fatalf("failed to open file: %s", err)
+        }
+
+        fileScanner := bufio.NewScanner(readFile)
+        fileScanner.Split(bufio.ScanLines)
+        var fileTextLines []string
+
+        for fileScanner.Scan() {
+            fileTextLines = append(fileTextLines, fileScanner.Text())
+        }
+
+        readFile.Close()
+
+        for _, eachline := range fileTextLines {
+            line := strings.Split(eachline, " ")
+            if len(line) != 2 {
+                log.Fatalf("Malformed line: %s", line)
+            }
+            key := fmt.Sprintf("{%s}", line[0])
+            value := line[1]
+            if v, err := format_args[key]; err {
+                log.Printf("WARNING: Duplicate value for key '%s': using '%s'", line[0], v)
+            }
+            format_args[key] = value
+        }
+    }
+
+    if value, err := format_args[*format]; err {
+        writeFile, err := os.Create(*output)
+
+        if err != nil {
+            log.Fatalf("failed to create file: %s", err)
+        }
+        writeFile.WriteString(value)
+        defer writeFile.Close()
+    } else {
+        log.Fatalf("ERROR: The stamp: '%s' not exists", *format)
+    }
+}

--- a/az/go/pkg/utils/BUILD.bazel
+++ b/az/go/pkg/utils/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["utils.go"],
+    importpath = "github.com/acqio/rules_microsoft_azure/az/go/pkg/utils",
+    visibility = ["//:__subpackages__"],
+)

--- a/az/go/pkg/utils/utils.go
+++ b/az/go/pkg/utils/utils.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+    "fmt"
+)
+
+// ArrayStringFlags are defined for string flags that may have multiple values.
+type ArrayStringFlags []string
+
+// Returns the concatenated string representation of the array of flags.
+func (f *ArrayStringFlags) String() string {
+    return fmt.Sprintf("%v", *f)
+}
+
+// Get returns an empty interface that may be type-asserted to the underlying
+// value of type bool, string, etc.
+func (f *ArrayStringFlags) Get() interface{} {
+    return ""
+}
+
+// Set appends value the array of flags.
+func (f *ArrayStringFlags) Set(value string) error {
+    *f = append(*f, value)
+    return nil
+}

--- a/az/private/common/utils.bzl
+++ b/az/private/common/utils.bzl
@@ -1,0 +1,24 @@
+def _check_stamping_format(f):
+    if f.startswith("{") and f.endswith("}"):
+        return True
+    return False
+
+def _resolve_stamp(ctx, string, output):
+    stamps = [ctx.info_file, ctx.version_file]
+    args = ctx.actions.args()
+    args.add_all(stamps, format_each = "--stamp-info-file=%s")
+    args.add(string, format = "--format=%s")
+    args.add(output, format = "--output=%s")
+    ctx.actions.run(
+        executable = ctx.executable._stamper,
+        arguments = [args],
+        inputs = stamps,
+        tools = [ctx.executable._stamper],
+        outputs = [output],
+        mnemonic = "Stamp",
+    )
+
+utils = struct(
+    resolve_stamp = _resolve_stamp,
+    check_stamping_format = _check_stamping_format,
+)

--- a/az/private/repositories.bzl
+++ b/az/private/repositories.bzl
@@ -7,3 +7,29 @@ def repositories():
         sha256 = "e5d90f0ec952883d56747b7604e2a15ee36e288bb556c3d0ed33e818a4d971f2",
         strip_prefix = "bazel-skylib-1.0.2",
     )
+
+    io_bazel_rules_go_version = "0.23.5"
+    io_bazel_rules_go_sha = "2d536797707dd1697441876b2e862c58839f975c8fc2f0f96636cbd428f45866"
+    http_archive(
+        name = "io_bazel_rules_go",
+        sha256 = io_bazel_rules_go_sha,
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/" +
+            "download/v{0}/rules_go-v{0}.tar.gz".format(io_bazel_rules_go_version),
+            "https://github.com/bazelbuild/rules_go/releases/" +
+            "download/v{0}/rules_go-v{0}.tar.gz".format(io_bazel_rules_go_version),
+        ],
+    )
+
+    bazel_gazelle_version = "0.21.1"
+    bazel_gazelle_sha = "cdb02a887a7187ea4d5a27452311a75ed8637379a1287d8eeb952138ea485f7d"
+    http_archive(
+        name = "bazel_gazelle",
+        sha256 = bazel_gazelle_sha,
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/" +
+            "download/v{0}/bazel-gazelle-v{0}.tar.gz".format(bazel_gazelle_version),
+            "https://github.com/bazelbuild/bazel-gazelle/releases/" +
+            "download/v{0}/bazel-gazelle-v{0}.tar.gz".format(bazel_gazelle_version),
+        ],
+    )

--- a/az/private/rules/config.bzl
+++ b/az/private/rules/config.bzl
@@ -1,25 +1,43 @@
 load("//az:providers/providers.bzl", "AzConfigInfo")
+load("//az/private/common:utils.bzl", "utils")
 
 def _impl(ctx):
     if ctx.attr.subscription.strip() == "":
         fail("The subscription attribute cannot be an empty string.")
 
-    debug = "--debug" if ctx.attr.debug else ""
-    subscription = "--subscription \"%s\"" % ctx.attr.subscription if ctx.attr.subscription.strip() != "" else ""
-    verbose = "--verbose" if ctx.attr.verbose else ""
+    debug_arg = "--debug" if ctx.attr.debug else ""
+    subscription_arg = "--subscription \"%s\"" % ctx.attr.subscription
+    verbose_arg = "--verbose" if ctx.attr.verbose else ""
+    files = []
+
+    if utils.check_stamping_format(ctx.attr.subscription):
+        subscription_file = ctx.actions.declare_file(ctx.label.name + ".subscription-name")
+        utils.resolve_stamp(ctx, ctx.attr.subscription, subscription_file)
+        subscription_arg = "--subscription $(cat \"%s\")" % subscription_file.short_path
+        files.append(subscription_file)
 
     return [
         AzConfigInfo(
             debug = ctx.attr.debug,
+            global_args = " ".join([debug_arg, subscription_arg, verbose_arg]),
             subscription = ctx.attr.subscription,
             verbose = ctx.attr.verbose,
-            global_args = " ".join([debug, subscription, verbose]),
+        ),
+        DefaultInfo(
+            runfiles = ctx.runfiles(
+                files = files,
+            ),
         ),
     ]
 
 config = rule(
     implementation = _impl,
     attrs = {
+        "_stamper": attr.label(
+            default = Label("//az/go/cmd/stamper"),
+            executable = True,
+            cfg = "host",
+        ),
         "debug": attr.bool(
             default = False,
         ),

--- a/az/providers/providers.bzl
+++ b/az/providers/providers.bzl
@@ -10,5 +10,5 @@ AzToolchainInfo = provider(
 )
 
 AzConfigInfo = provider(
-    fields = ["debug", "subscription", "verbose", "global_args"],
+    fields = ["debug", "global_args", "subscription", "verbose"],
 )

--- a/tools/workspace_status.sh
+++ b/tools/workspace_status.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+echo "STABLE_AZ_SUBSCRIPTION foo-subscription"


### PR DESCRIPTION
Added artifacts for building and creating stamping files

To create stamping files, we are creating a program to run in the build phase to read variables from the workspace.
This program was done in GoLang. The executable is created from the rules_go rules of bazel.
The rules_gazelle rule was also used to automate the process of creating BUILD.bazel, defining dependencies, among other facilities.